### PR TITLE
typo

### DIFF
--- a/algtopo.tex
+++ b/algtopo.tex
@@ -241,7 +241,7 @@
 \end{bem}
 
 % 3.2
-\begin{prop}[Schlangenlemma]
+\begin{prop}
   Die ex. Sequenz $0 \to \CC{A} \to \CC{B} \to \CC{C} \to 0$ induziert in jedem Grad einen sogenannten \emph{verbindenden Homomorphismus} $\partial_n : H_n(C) \to H_{n-1}(A)$, sodass die Sequenz
   \[ ... \to H_n(A) \to H_n(B) \to H_n(C) \xrightarrow{\partial_n} H_{n-1}(A) \to H_{n-1}(B) \to ... \]
   exakt ist. Diese Sequenz wird \emph{lange exakte Sequenz} genannt.
@@ -1091,7 +1091,7 @@
 \begin{defn}
   Sei $H$ eine ab. Gruppe. Eine \emph{freie Auflösung} von $H$ ist ein azyklischer Kettenkomplex
   \[
-    ... \to F_3 \to F_2 \to F_1 \to F_1 \to H \to H
+    ... \to F_3 \to F_2 \to F_1 \to F_1 \to H \to 0
     \quad \text{(kurz: $F_* \to H$),}
   \]
   bestehend aus freien abelschen Gruppen $F_i$, $i \geq 0$.


### PR DESCRIPTION
Ich habe noch nie gehört, dass das Lemma, das die lange exakte Sequenz in Homologie zu einer kurzen exakten Sequenz von Kettenkomplexen, "Schlangenlemma" genannt wird. Um aus dem richtigen Schlangenlemma die Proposition zu folgern, muss man doch zunächst ausgehend von der gegebenen Sequenz von Komplexen ein neues Diagramm bauen, das in der Zeile A^n/im d (bzw. B und C) und in der zweiten Zeile ker d (auf A, B bzw. C) stehen hat. Aber wenn es so in der Vorlesung hieß, sollte die Überschrift natürlich bleiben. :-)

Die zweite Änderung ist ein trivialer Typo.

(Sorry für den Lärm um die letzte Zeile. Arbeite gerade vom Webinterface aus.)