### PR TITLE
p-adische *Ganz*zahlen

### DIFF
--- a/kommalg.tex
+++ b/kommalg.tex
@@ -3251,7 +3251,7 @@ Sei $A$ ein Integritätsbereich mit Quotientenkörper~$K$.
     \item Sei $K$ ein Körper.
     Dann ist $\widehat{K[x]}_{(x)} = K \llbracket x \rrbracket$.
     \item Sei $p$ eine Primzahl.
-    Dann heißt $\Z_p \coloneqq \hat{\Z}_{(p)}$ \emph{Ring der $p$-adischen Zahlen}.
+    Dann heißt $\Z_p \coloneqq \hat{\Z}_{(p)}$ \emph{Ring der $p$-adischen Ganzzahlen}.
     Elemente aus $\Z_p$ kann man als Reihen ${\sum}_{n=0}^\infty a_n p^n$ mit $0 \leq a_n < p$ schreiben.
     Es gilt dabei $\lim_{n \to \infty} p^n = 0$.
   \end{itemize}


### PR DESCRIPTION
Das ist im Skript nicht ganz richtig. Mit "den p-adischen Zahlen" meint man für gewöhnlich Q_p, das ist der Quotientenkörper des Integritätsbereichs Z_p.